### PR TITLE
Spotify Muting

### DIFF
--- a/GTASARadioExternal/App.config
+++ b/GTASARadioExternal/App.config
@@ -1,18 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="gameSet" value=""/>
-    <add key="playerSet" value=""/>
-    <add key="actionSet" value=""/>
-    <add key="quickvolumeSet" value=""/>
-    <add key="ignoremodifiersSet" value=""/>
-    <add key="emergencySet" value=""/>
-    <add key="radioSet" value=""/>
-    <add key="interiorsSet" value=""/>
-    <add key="announcerSet" value=""/>
-    <add key="kaufmanSet" value=""/>
-    <add key="menuSet" value=""/>
-      
+    <add key="gameSet" value="False"/>
+    <add key="playerSet" value="False"/>
+    <add key="actionSet" value="False"/>
+    <add key="quickvolumeSet" value="False"/>
+    <add key="ignoremodifiersSet" value="False"/>
+    <add key="emergencySet" value="False"/>
+    <add key="radioSet" value="False"/>
+    <add key="interiorsSet" value="False"/>
+    <add key="announcerSet" value="False"/>
+    <add key="kaufmanSet" value="False"/>
+    <add key="menuSet" value="False"/>
+    <add key="spotifyMixerMaxVolume" value="100"/>
+    <add key="defaultAudioSource" value=""/>
   </appSettings>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />

--- a/GTASARadioExternal/Form1.Designer.cs
+++ b/GTASARadioExternal/Form1.Designer.cs
@@ -33,11 +33,15 @@
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
 			this.label2 = new System.Windows.Forms.Label();
 			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.radioButtonSpotify = new System.Windows.Forms.RadioButton();
 			this.radioButtonOther = new System.Windows.Forms.RadioButton();
 			this.radioButtonWinamp = new System.Windows.Forms.RadioButton();
 			this.radioButtonFoobar = new System.Windows.Forms.RadioButton();
 			this.labelVolume = new System.Windows.Forms.Label();
 			this.groupBox3 = new System.Windows.Forms.GroupBox();
+			this.label4 = new System.Windows.Forms.Label();
+			this.comboBoxAudioSources = new System.Windows.Forms.ComboBox();
+			this.radioButtonMuteSpotify = new System.Windows.Forms.RadioButton();
 			this.checkBox7 = new System.Windows.Forms.CheckBox();
 			this.checkBox1 = new System.Windows.Forms.CheckBox();
 			this.radioButtonVolume = new System.Windows.Forms.RadioButton();
@@ -51,10 +55,14 @@
 			this.checkBoxC = new System.Windows.Forms.CheckBox();
 			this.checkBoxB = new System.Windows.Forms.CheckBox();
 			this.checkBoxA = new System.Windows.Forms.CheckBox();
+			this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+			this.numericMixerMaxVolume = new System.Windows.Forms.NumericUpDown();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
 			this.groupBox3.SuspendLayout();
 			this.groupBox4.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericMixerMaxVolume)).BeginInit();
 			this.SuspendLayout();
 			// 
 			// label1
@@ -71,7 +79,7 @@
 			// 
 			this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.label3.AutoSize = true;
-			this.label3.Location = new System.Drawing.Point(66, 313);
+			this.label3.Location = new System.Drawing.Point(108, 417);
 			this.label3.Name = "label3";
 			this.label3.Size = new System.Drawing.Size(207, 13);
 			this.label3.TabIndex = 4;
@@ -141,12 +149,13 @@
 			// 
 			// groupBox2
 			// 
+			this.groupBox2.Controls.Add(this.radioButtonSpotify);
 			this.groupBox2.Controls.Add(this.radioButtonOther);
 			this.groupBox2.Controls.Add(this.radioButtonWinamp);
 			this.groupBox2.Controls.Add(this.radioButtonFoobar);
 			this.groupBox2.Location = new System.Drawing.Point(108, 33);
 			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Size = new System.Drawing.Size(168, 109);
+			this.groupBox2.Size = new System.Drawing.Size(207, 109);
 			this.groupBox2.TabIndex = 7;
 			this.groupBox2.TabStop = false;
 			this.groupBox2.Text = "Music Player";
@@ -154,10 +163,24 @@
         "olume up/down keys. Please bind these manually if desiring to use the Volume opt" +
         "ion with Foobar\r\n");
 			// 
+			// radioButtonSpotify
+			// 
+			this.radioButtonSpotify.AutoSize = true;
+			this.radioButtonSpotify.Location = new System.Drawing.Point(6, 63);
+			this.radioButtonSpotify.Name = "radioButtonSpotify";
+			this.radioButtonSpotify.Size = new System.Drawing.Size(130, 17);
+			this.radioButtonSpotify.TabIndex = 9;
+			this.radioButtonSpotify.Text = "Spotify (App via Mixer)";
+			this.toolTip1.SetToolTip(this.radioButtonSpotify, "Select which Music Player you are using\r\nNote: Foobar does not natively support v" +
+        "olume up/down keys. Please bind these manually if desiring to use the Volume opt" +
+        "ion with Foobar\r\n");
+			this.radioButtonSpotify.UseVisualStyleBackColor = true;
+			this.radioButtonSpotify.CheckedChanged += new System.EventHandler(this.radioButtonSpotify_CheckedChanged);
+			// 
 			// radioButtonOther
 			// 
 			this.radioButtonOther.AutoSize = true;
-			this.radioButtonOther.Location = new System.Drawing.Point(6, 65);
+			this.radioButtonOther.Location = new System.Drawing.Point(6, 86);
 			this.radioButtonOther.Name = "radioButtonOther";
 			this.radioButtonOther.Size = new System.Drawing.Size(51, 17);
 			this.radioButtonOther.TabIndex = 8;
@@ -208,6 +231,10 @@
 			// 
 			// groupBox3
 			// 
+			this.groupBox3.Controls.Add(this.numericMixerMaxVolume);
+			this.groupBox3.Controls.Add(this.label4);
+			this.groupBox3.Controls.Add(this.comboBoxAudioSources);
+			this.groupBox3.Controls.Add(this.radioButtonMuteSpotify);
 			this.groupBox3.Controls.Add(this.checkBox7);
 			this.groupBox3.Controls.Add(this.checkBox1);
 			this.groupBox3.Controls.Add(this.radioButtonVolume);
@@ -215,11 +242,43 @@
 			this.groupBox3.Controls.Add(this.radioButtonMute);
 			this.groupBox3.Location = new System.Drawing.Point(15, 148);
 			this.groupBox3.Name = "groupBox3";
-			this.groupBox3.Size = new System.Drawing.Size(263, 91);
+			this.groupBox3.Size = new System.Drawing.Size(300, 142);
 			this.groupBox3.TabIndex = 9;
 			this.groupBox3.TabStop = false;
 			this.groupBox3.Text = "Action";
 			this.toolTip1.SetToolTip(this.groupBox3, resources.GetString("groupBox3.ToolTip"));
+			// 
+			// label4
+			// 
+			this.label4.AutoSize = true;
+			this.label4.Location = new System.Drawing.Point(120, 115);
+			this.label4.Name = "label4";
+			this.label4.Size = new System.Drawing.Size(111, 13);
+			this.label4.TabIndex = 12;
+			this.label4.Text = "Spotify Mixer Max Vol.";
+			// 
+			// comboBoxAudioSources
+			// 
+			this.comboBoxAudioSources.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxAudioSources.FormattingEnabled = true;
+			this.comboBoxAudioSources.Location = new System.Drawing.Point(123, 87);
+			this.comboBoxAudioSources.Name = "comboBoxAudioSources";
+			this.comboBoxAudioSources.Size = new System.Drawing.Size(148, 21);
+			this.comboBoxAudioSources.TabIndex = 10;
+			this.comboBoxAudioSources.SelectedIndexChanged += new System.EventHandler(this.comboBoxAudioSources_SelectedIndexChanged);
+			// 
+			// radioButtonMuteSpotify
+			// 
+			this.radioButtonMuteSpotify.AutoSize = true;
+			this.radioButtonMuteSpotify.Enabled = false;
+			this.radioButtonMuteSpotify.Location = new System.Drawing.Point(6, 88);
+			this.radioButtonMuteSpotify.Name = "radioButtonMuteSpotify";
+			this.radioButtonMuteSpotify.Size = new System.Drawing.Size(100, 17);
+			this.radioButtonMuteSpotify.TabIndex = 9;
+			this.radioButtonMuteSpotify.Text = "Mute from Mixer";
+			this.toolTip1.SetToolTip(this.radioButtonMuteSpotify, resources.GetString("radioButtonMuteSpotify.ToolTip"));
+			this.radioButtonMuteSpotify.UseVisualStyleBackColor = true;
+			this.radioButtonMuteSpotify.CheckedChanged += new System.EventHandler(this.radioButtonMuteSpotify_CheckedChanged);
 			// 
 			// checkBox7
 			// 
@@ -295,9 +354,9 @@
 			this.groupBox4.Controls.Add(this.checkBoxC);
 			this.groupBox4.Controls.Add(this.checkBoxB);
 			this.groupBox4.Controls.Add(this.checkBoxA);
-			this.groupBox4.Location = new System.Drawing.Point(15, 245);
+			this.groupBox4.Location = new System.Drawing.Point(15, 305);
 			this.groupBox4.Name = "groupBox4";
-			this.groupBox4.Size = new System.Drawing.Size(261, 65);
+			this.groupBox4.Size = new System.Drawing.Size(300, 65);
 			this.groupBox4.TabIndex = 10;
 			this.groupBox4.TabStop = false;
 			this.groupBox4.Text = "When";
@@ -381,11 +440,23 @@
 			this.checkBoxA.UseVisualStyleBackColor = true;
 			this.checkBoxA.CheckedChanged += new System.EventHandler(this.checkBoxA_CheckedChanged);
 			// 
+			// errorProvider1
+			// 
+			this.errorProvider1.ContainerControl = this;
+			// 
+			// numericMixerMaxVolume
+			// 
+			this.numericMixerMaxVolume.Location = new System.Drawing.Point(230, 113);
+			this.numericMixerMaxVolume.Name = "numericMixerMaxVolume";
+			this.numericMixerMaxVolume.Size = new System.Drawing.Size(41, 20);
+			this.numericMixerMaxVolume.TabIndex = 13;
+			this.numericMixerMaxVolume.ValueChanged += new System.EventHandler(this.numericUpDown1_ValueChanged);
+			// 
 			// Form1
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(288, 332);
+			this.ClientSize = new System.Drawing.Size(330, 436);
 			this.Controls.Add(this.groupBox4);
 			this.Controls.Add(this.groupBox3);
 			this.Controls.Add(this.labelVolume);
@@ -406,6 +477,8 @@
 			this.groupBox3.PerformLayout();
 			this.groupBox4.ResumeLayout(false);
 			this.groupBox4.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericMixerMaxVolume)).EndInit();
 			this.ResumeLayout(false);
 			this.PerformLayout();
 
@@ -439,6 +512,12 @@
 		private System.Windows.Forms.CheckBox checkBoxE;
 		private System.Windows.Forms.CheckBox checkBoxF;
 		private System.Windows.Forms.CheckBox checkBox7;
+		private System.Windows.Forms.RadioButton radioButtonMuteSpotify;
+		private System.Windows.Forms.RadioButton radioButtonSpotify;
+		private System.Windows.Forms.ComboBox comboBoxAudioSources;
+		private System.Windows.Forms.ErrorProvider errorProvider1;
+		private System.Windows.Forms.Label label4;
+		private System.Windows.Forms.NumericUpDown numericMixerMaxVolume;
 	}
 }
 

--- a/GTASARadioExternal/Form1.cs
+++ b/GTASARadioExternal/Form1.cs
@@ -9,11 +9,13 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Diagnostics;
 using System.Configuration;
+using CSCore.CoreAudioAPI;
 
 namespace GTASARadioExternal {
 	public partial class Form1 : Form {
-
 		Timer timer2;
+
+		string savedAudioSource = "";
 
 		public enum displayedTexts { Unitialized, Shutdown, Running, Unrecognized, Unconfirmed, NoMusicPlayer }
 		displayedTexts displayedText = displayedTexts.Unitialized;
@@ -52,8 +54,10 @@ namespace GTASARadioExternal {
 			else if (radioButtonOther.Checked) {
 				readMemory.DeterminePlayerVersionOther();
 			}
+			else if (radioButtonSpotify.Checked) {
+				readMemory.DeterminePlayerVersionOther();
+			}
 		}
-
 
 		void UpdateWindow() {
 			if (readMemory.actionToTake == ReadMemory.actions.None) {
@@ -153,6 +157,10 @@ namespace GTASARadioExternal {
 		}
 
 		private void radioButtonVolume_CheckedChanged(object sender, EventArgs e) {
+			comboBoxAudioSources.Enabled = false;
+			comboBoxAudioSources.Items.Clear();
+			numericMixerMaxVolume.Enabled = false;
+
 			readMemory.actionToTake = ReadMemory.actions.Volume;
 			checkBox1.Enabled = radioButtonVolume.Checked;
 			readMemory.maxVolumeWriteable = false;
@@ -162,6 +170,9 @@ namespace GTASARadioExternal {
 		private void radioButtonPause_CheckedChanged(object sender, EventArgs e) {
 			readMemory.isPaused = false;
 			if (radioButtonPause.Checked) {
+				comboBoxAudioSources.Enabled = false;
+				comboBoxAudioSources.Items.Clear();
+				numericMixerMaxVolume.Enabled = false;
 				readMemory.actionToTake = ReadMemory.actions.Pause;
 			}
 			readMemory.maxVolumeWriteable = false;
@@ -170,6 +181,10 @@ namespace GTASARadioExternal {
 		private void radioButtonMute_CheckedChanged(object sender, EventArgs e) {
 			readMemory.isMuted = false;
 			if (radioButtonMute.Checked) {
+				comboBoxAudioSources.Enabled = false;
+				comboBoxAudioSources.Items.Clear();
+				errorProvider1.Clear();
+				numericMixerMaxVolume.Enabled = false;
 				readMemory.actionToTake = ReadMemory.actions.Mute;
 			}
 			readMemory.maxVolumeWriteable = false;
@@ -177,19 +192,31 @@ namespace GTASARadioExternal {
 
 		private void radioButtonOther_CheckedChanged(object sender, EventArgs e) {
 			if (radioButtonOther.Checked) {
+				comboBoxAudioSources.Enabled = false;
+				comboBoxAudioSources.Items.Clear();
+				errorProvider1.Clear();
+				numericMixerMaxVolume.Enabled = false;
 				readMemory.musicP = ReadMemory.musicPlayers.Other;
 				radioButtonVolume.Enabled = !radioButtonOther.Checked;
 				radioButtonMute.Enabled = !radioButtonOther.Checked;
 				radioButtonPause.Enabled = radioButtonOther.Checked;
+				radioButtonPause.Checked = true; // Reset selection so the radiobuttons doesn't get fucky
+				radioButtonMuteSpotify.Enabled = !radioButtonOther.Checked;
 				readMemory.maxVolumeWriteable = false;
 			}
 		}
 
 		private void radioButtonWinamp_CheckedChanged(object sender, EventArgs e) {
 			if (radioButtonWinamp.Checked) {
+				comboBoxAudioSources.Enabled = false;
+				comboBoxAudioSources.Items.Clear();
+				errorProvider1.Clear();
+				numericMixerMaxVolume.Enabled = false;
 				radioButtonVolume.Enabled = radioButtonWinamp.Checked;
 				radioButtonMute.Enabled = radioButtonWinamp.Checked;
+				radioButtonMute.Checked = true; // Reset selection so the radiobuttons doesn't get fucky
 				radioButtonPause.Enabled = radioButtonWinamp.Checked;
+				radioButtonMuteSpotify.Enabled = !radioButtonWinamp.Checked;
 				readMemory.musicP = ReadMemory.musicPlayers.Winamp;
 				readMemory.maxVolumeWriteable = false;
 				readMemory.DeterminePlayerVersionWinamp();
@@ -199,9 +226,15 @@ namespace GTASARadioExternal {
 
 		private void radioButtonFoobar_CheckedChanged(object sender, EventArgs e) {
 			if (radioButtonFoobar.Checked) {
+				comboBoxAudioSources.Enabled = false;
+				comboBoxAudioSources.Items.Clear();
+				errorProvider1.Clear();
+				numericMixerMaxVolume.Enabled = false;
 				radioButtonVolume.Enabled = radioButtonFoobar.Checked;
 				radioButtonMute.Enabled = radioButtonFoobar.Checked;
+				radioButtonMute.Checked = true; // Reset selection so the radiobuttons doesn't get fucky
 				radioButtonPause.Enabled = radioButtonFoobar.Checked;
+				radioButtonMuteSpotify.Enabled = !radioButtonFoobar.Checked;
 				readMemory.musicP = ReadMemory.musicPlayers.Foobar;
 				readMemory.maxVolumeWriteable = false;
 				readMemory.DeterminePlayerVersionFoobar();
@@ -212,16 +245,82 @@ namespace GTASARadioExternal {
 
 		private void radioButtonVolume_EnabledChanged(object sender, EventArgs e) {
 			if (radioButtonVolume.Checked) {
+				comboBoxAudioSources.Enabled = false;
+				comboBoxAudioSources.Items.Clear();
+				errorProvider1.Clear();
+				numericMixerMaxVolume.Enabled = false;
 				radioButtonVolume.Checked = false;
 				readMemory.actionToTake = ReadMemory.actions.None;
 				radioButtonPause.Checked = true;
 				readMemory.DeterminePlayerVersionOther();
 			}
 		}
+
+		private void radioButtonSpotify_CheckedChanged(object sender, EventArgs e) {
+			if (radioButtonSpotify.Checked) {
+				readMemory.musicP = ReadMemory.musicPlayers.Other;
+				radioButtonVolume.Enabled = !radioButtonSpotify.Checked;
+				radioButtonMute.Enabled = !radioButtonSpotify.Checked;
+				radioButtonPause.Enabled = radioButtonSpotify.Checked;
+				radioButtonPause.Checked = true; // Reset selection so the radiobuttons doesn't get fucky
+				radioButtonMuteSpotify.Enabled = radioButtonSpotify.Checked;
+				readMemory.maxVolumeWriteable = false;
+			}
+		}
+
+		/// <summary>
+		/// Derived this Spotify-functionality from the pause method
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		private void radioButtonMuteSpotify_CheckedChanged(object sender, EventArgs e) {
+			readMemory.isPaused = false;
+			if (radioButtonMuteSpotify.Checked) {
+				comboBoxAudioSources.Enabled = radioButtonMuteSpotify.Checked;
+				comboBoxAudioSources.Items.Clear();
+				numericMixerMaxVolume.Enabled = true;
+				using (var enumerator = new MMDeviceEnumerator()) {
+					// Find all Audiosources for the combobox selection (We can't use the Default Device, if someone has set Spotify to play music on a specific Audiosource)
+					var sources = enumerator.EnumAudioEndpoints(DataFlow.Render, DeviceState.Active);
+
+					// Populate the ComboBox
+					foreach (var s in sources) {
+						comboBoxAudioSources.Items.Add(s.FriendlyName);
+					}
+					// Select saved audiosource (if any)
+					if (comboBoxAudioSources.Items.Contains(savedAudioSource))
+						comboBoxAudioSources.SelectedItem = savedAudioSource;
+				}
+
+				// The Audiosource selection is required so lets set an errorProvider to notify the user
+				errorProvider1.SetError(comboBoxAudioSources, "Select the AudioSource Spotify uses.");
+
+				readMemory.actionToTake = ReadMemory.actions.SpotifyMute;
+			}
+			// If we change the muting style, ensure that the volume on the mixer is set back to max
+			else {
+				Task.Run(() => ReadMemory.MuteUnMuteSpotify(false));
+			}
+			readMemory.maxVolumeWriteable = false;
+		}
+		private void comboBoxAudioSources_SelectedIndexChanged(object sender, EventArgs e) {
+			ReadMemory.spotifyAudioSourceName = comboBoxAudioSources.SelectedItem as string;
+
+			errorProvider1.Clear();
+		}
+
 		#endregion
 
 		#region game radio buttons
 		private void radioButtonIII_CheckedChanged(object sender, EventArgs e) {
+
+			// Spotify muting is enabled only on SA for now, since I haven't tested the other two.
+			if (radioButtonIII.Checked) {
+				radioButtonSpotify.Enabled = false;
+				if (radioButtonSpotify.Checked)
+					radioButtonWinamp.Checked = true;
+			}
+
 			readMemory.DetermineGameVersionIII();
 			readMemory.game = ReadMemory.games.III;
 			checkBoxA.Enabled = true;
@@ -242,6 +341,13 @@ namespace GTASARadioExternal {
 		}
 
 		private void radioButtonVC_CheckedChanged(object sender, EventArgs e) {
+
+			// Spotify muting is enabled only on SA for now, since I haven't tested the other two.
+			if (radioButtonVC.Checked) {
+				radioButtonSpotify.Enabled = false;
+				if (radioButtonSpotify.Checked)
+					radioButtonWinamp.Checked = true;
+			}
 			readMemory.DetermineGameVersionVC();
 			readMemory.game = ReadMemory.games.VC;
 			checkBoxA.Enabled = true;
@@ -262,6 +368,10 @@ namespace GTASARadioExternal {
 		}
 
 		private void radioButtonSA_CheckedChanged(object sender, EventArgs e) {
+			// Spotify muting is enabled only on SA for now, since I haven't tested the other two.
+			if (radioButtonSA.Checked)
+				radioButtonSpotify.Enabled = true;
+
 			readMemory.DetermineGameVersionSA();
 			readMemory.game = ReadMemory.games.SA;
 			checkBoxA.Enabled = false;
@@ -294,7 +404,6 @@ namespace GTASARadioExternal {
 		}
 
 		private void checkBoxC_CheckedChanged(object sender, EventArgs e) {
-
 		}
 
 		private void checkBoxD_CheckedChanged(object sender, EventArgs e) {
@@ -327,6 +436,8 @@ namespace GTASARadioExternal {
 		private void Form1_FormClosing(object sender, FormClosingEventArgs e) {
 
 			try {
+				Task.Run(() => ReadMemory.MuteUnMuteSpotify(false));
+
 				Configuration config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
 
 				if (radioButtonSA.Checked) {
@@ -351,8 +462,12 @@ namespace GTASARadioExternal {
 				else if (radioButtonFoobar.Checked) {
 					config.AppSettings.Settings["playerSet"].Value = "Foobar";
 				}
-				else if (radioButtonVolume.Checked) {
+				else if (radioButtonOther.Checked) // Here was a typo?
+				{
 					config.AppSettings.Settings["playerSet"].Value = "Other";
+				}
+				else if (radioButtonSpotify.Checked) {
+					config.AppSettings.Settings["playerSet"].Value = "Spotify";
 				}
 				//action
 				if (radioButtonMute.Checked) {
@@ -364,6 +479,9 @@ namespace GTASARadioExternal {
 				else if (radioButtonVolume.Checked) {
 					config.AppSettings.Settings["actionSet"].Value = "Volume";
 				}
+				else if (radioButtonMuteSpotify.Checked) {
+					config.AppSettings.Settings["actionSet"].Value = "Spotify";
+				}
 				//action-settings
 				config.AppSettings.Settings["quickvolumeSet"].Value = checkBox1.Checked.ToString();
 				config.AppSettings.Settings["ignoremodifiersSet"].Value = checkBox7.Checked.ToString();
@@ -374,6 +492,9 @@ namespace GTASARadioExternal {
 				config.AppSettings.Settings["announcerSet"].Value = checkBoxF.Checked.ToString();
 				config.AppSettings.Settings["kaufmanSet"].Value = checkBoxE.Checked.ToString();
 				config.AppSettings.Settings["menuSet"].Value = checkBoxD.Checked.ToString();
+
+				config.AppSettings.Settings["spotifyMixerMaxVolume"].Value = numericMixerMaxVolume.Value.ToString();
+				config.AppSettings.Settings["defaultAudioSource"].Value = (comboBoxAudioSources.SelectedItem != null) ? comboBoxAudioSources.SelectedItem.ToString() : "";
 
 				config.Save(ConfigurationSaveMode.Modified);
 			}
@@ -407,6 +528,9 @@ namespace GTASARadioExternal {
 					case "Other":
 						radioButtonOther.Checked = true;
 						break;
+					case "Spotify":
+						radioButtonSpotify.Checked = true;
+						break;
 					default:
 						break;
 				}
@@ -420,6 +544,9 @@ namespace GTASARadioExternal {
 					case "Volume":
 						radioButtonVolume.Checked = true;
 						break;
+					case "Spotify":
+						radioButtonMuteSpotify.Checked = true;
+						break;
 					default:
 						break;
 				}
@@ -431,19 +558,31 @@ namespace GTASARadioExternal {
 				checkBoxF.Checked = bool.Parse(ConfigurationManager.AppSettings["announcerSet"]);
 				checkBoxE.Checked = bool.Parse(ConfigurationManager.AppSettings["kaufmanSet"]);
 				checkBoxD.Checked = bool.Parse(ConfigurationManager.AppSettings["menuSet"]);
+
+				savedAudioSource = ConfigurationManager.AppSettings["defaultAudioSource"];
+				// Select saved audiosource (if any)
+				if (comboBoxAudioSources.Items.Contains(savedAudioSource))
+					comboBoxAudioSources.SelectedItem = savedAudioSource;
+
+				int maxVolume;
+				bool success = int.TryParse(ConfigurationManager.AppSettings["spotifyMixerMaxVolume"], out maxVolume);
+
+				if (!success)
+					maxVolume = 100;
+				ReadMemory.spotifyMixerMaxVolume = maxVolume;
+				numericMixerMaxVolume.Value = maxVolume;
 			}
 
 			catch (NullReferenceException) {
 				Debug.WriteLine("Error reading app settings");
 			}
 		}
-
-
-
-
-
 		#endregion
 
-
+		private void numericUpDown1_ValueChanged(object sender, EventArgs e) {
+			//Set the maximum Mixer volume from the selector
+			int volume = (int)numericMixerMaxVolume.Value;
+			ReadMemory.spotifyMixerMaxVolume = volume;
+		}
 	}
 }

--- a/GTASARadioExternal/Form1.resx
+++ b/GTASARadioExternal/Form1.resx
@@ -123,6 +123,22 @@
   <metadata name="radioButtonWinamp.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="radioButtonWinamp.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="radioButtonMuteSpotify.ToolTip" xml:space="preserve">
+    <value>The action to take when the radio is supposed to turn on/off. 
+Volume = Volume up/down multimedia key presses are sent repeatedly until the volume is correct. When playing music at high volumes, this can take up to a couple seconds. 
+Toggling 'Quick Volume' will speed this process, but volume restoration is less precise. 
+Toggling 'Ignore Modifiers' will ignore modifier keys, which will cause systemwide volume change when holding modifier keys (shift, alt, ctrl) when transitioning radio status. Enable if you have a virtual audio cable setup where system volume doesn't matter.
+  Note: Certain programs may need to have the media keys bound manually.
+Mute = Mute/unmute commands are sent. No fake keypresses are sent. (recommended)
+Play/pause = Play/pause is sent. Unlike the true GTA experience, the music is paused and resumed and will not continue playing silently in the background. Note: Pausing/Playing manually may be needed to prevent inverted radio playing.
+</value>
+  </data>
   <data name="checkBox7.ToolTip" xml:space="preserve">
     <value>The action to take when the radio is supposed to turn on/off. 
 Volume = Volume up/down multimedia key presses are sent repeatedly until the volume is correct. When playing music at high volumes, this can take up to a couple seconds. 
@@ -181,7 +197,17 @@ Toggling 'Ignore Modifiers' will ignore modifier keys, which will cause systemwi
   Note: Certain programs may need to have the media keys bound manually.
 Mute = Mute/unmute commands are sent. No fake keypresses are sent. (recommended)
 Play/pause = Play/pause is sent. Unlike the true GTA experience, the music is paused and resumed and will not continue playing silently in the background. Note: Pausing/Playing manually may be needed to prevent inverted radio playing.
+Mute from Mixer = Mutes Spotify App via Volume Mixer. You must select the AudioSource where Spotify is playing. This is usually the Default Device, if you haven't specifically set it to something else in the Mixer.
 </value>
+  </data>
+  <data name="groupBox4.ToolTip" xml:space="preserve">
+    <value>Select when the music should be playing. 
+Emergency = music player will be playing when the game is playing Emergency Radio (Firetrucks, Ambulances, Police Cars)
+Radio = music player will be playing when the game is on a regular radio station (Both music radio &amp; talk radio)
+Interiors = music player will be playing in interiors that have radio playing inside them (Does not include interiors with their own special music, such as Malibu or Caligula)
+Menu = music will play in pause menu (disregards whether it was playing to begin with)
+Kaufman = music will play in Kaufman Cab after Cabmaggedon
+Announcer = music will play during bridge repair/storm warning announcements on the radio</value>
   </data>
   <data name="checkBoxF.ToolTip" xml:space="preserve">
     <value>Select when the music should be playing. 
@@ -237,15 +263,9 @@ Menu = music will play in pause menu (disregards whether it was playing to begin
 Kaufman = music will play in Kaufman Cab after Cabmaggedon
 Announcer = music will play during bridge repair/storm warning announcements on the radio</value>
   </data>
-  <data name="groupBox4.ToolTip" xml:space="preserve">
-    <value>Select when the music should be playing. 
-Emergency = music player will be playing when the game is playing Emergency Radio (Firetrucks, Ambulances, Police Cars)
-Radio = music player will be playing when the game is on a regular radio station (Both music radio &amp; talk radio)
-Interiors = music player will be playing in interiors that have radio playing inside them (Does not include interiors with their own special music, such as Malibu or Caligula)
-Menu = music will play in pause menu (disregards whether it was playing to begin with)
-Kaufman = music will play in Kaufman Cab after Cabmaggedon
-Announcer = music will play during bridge repair/storm warning announcements on the radio</value>
-  </data>
+  <metadata name="errorProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>114, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/GTASARadioExternal/GTARadioExternal.csproj
+++ b/GTASARadioExternal/GTARadioExternal.csproj
@@ -67,6 +67,9 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CSCore, Version=1.2.1.2, Culture=neutral, PublicKeyToken=5a08f2b6f4415dea, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSCore.1.2.1.2\lib\net35-client\CSCore.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
@@ -102,6 +105,7 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/GTASARadioExternal/ReadMemory.cs
+++ b/GTASARadioExternal/ReadMemory.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.IO;
+using CSCore.CoreAudioAPI;
 
 namespace GTASARadioExternal {
 	public class ReadMemory {
@@ -30,13 +31,13 @@ namespace GTASARadioExternal {
 		public int address_running = 0x0;   // The address of the int that reads whether the music player is on or not
 		public int address_base = 0x0;
 		public string executable_location;  // Executable location
-		public int window_name;			// Window name
+		public int window_name;         // Window name
 		Timer timer1;
 		public bool maxVolumeWriteable = true;
 		public bool quickVolume = false;
 		public bool isPaused = false;
 		public bool isMuted = false;
-		public enum actions { None, Volume, Mute, Pause }
+		public enum actions { None, Volume, Mute, Pause, SpotifyMute }
 		public actions actionToTake;
 
 		public int failSafeAttempts = 0;
@@ -58,7 +59,9 @@ namespace GTASARadioExternal {
 		public bool radioPlayDuringAnnouncement;
 		public bool radioPlayDuringInterior;
 
-
+		// Name for the AudioSource Spotify uses
+		public static string spotifyAudioSourceName = "";
+		public static int spotifyMixerMaxVolume = 100;
 
 		// Dont know what this does
 		const int PROCESS_WM_READ = 0x0010;
@@ -243,13 +246,11 @@ namespace GTASARadioExternal {
 				//q[0].Modules
 				address_base = q[0].MainModule.BaseAddress.ToInt32();
 
-				foreach (ProcessModule i in q[0].Modules)
-				{
-					if (i.ModuleName == "out_ds.dll")
-					{
+				foreach (ProcessModule i in q[0].Modules) {
+					if (i.ModuleName == "out_ds.dll") {
 						address_volume = i.BaseAddress.ToInt32() + 0xB0A0;      // TODO: Make this modular or something so this isn't hardcoded and adding new programs is easy.
 						break;
-					}										
+					}
 				}
 				address_running = address_base + 0xBD1EC;
 				window_name = FindWindow("Winamp v1.x", null);
@@ -396,8 +397,8 @@ namespace GTASARadioExternal {
 					#endregion
 
 					volumeStatus = checkMP3PlayerStatus();
-					RadioChangerVolume(radioStatus >= 0 && radioStatus <= 9 && radioPlayDuringRadio 
-											|| radioStatus == 10 && radioPlayDuringEmergency == true 
+					RadioChangerVolume(radioStatus >= 0 && radioStatus <= 9 && radioPlayDuringRadio
+											|| radioStatus == 10 && radioPlayDuringEmergency == true
 											|| radioStatus >= 13 && radioStatus <= 14 && radioPlayDuringAnnouncement == true
 											|| radioStatus == 197 && radioPlayDuringPauseMenu == true
 					);
@@ -497,7 +498,7 @@ namespace GTASARadioExternal {
 						return;
 					}
 
-					if (radioStatus >= 0 && radioStatus <= 9  && radioPlayDuringRadio == true && isPaused == true) {
+					if (radioStatus >= 0 && radioStatus <= 9 && radioPlayDuringRadio == true && isPaused == true) {
 						isPaused = false;
 						RadioChangerPause(isPaused);
 					}
@@ -692,7 +693,7 @@ namespace GTASARadioExternal {
 						gameStatus = statuses.Shutdown;
 						return;
 					}
-
+					
 					if (radioStatus == 2 && isPaused == true) {
 						isPaused = false;
 						RadioChangerPause(isPaused);
@@ -700,6 +701,39 @@ namespace GTASARadioExternal {
 					else if (radioStatus == 7 && isPaused == false) {
 						isPaused = true;
 						RadioChangerPause(isPaused);
+					}
+				}
+			}
+			else if (actionToTake == actions.SpotifyMute) {
+				if (gameStatus == statuses.Running || gameStatus == statuses.Unconfirmed) {
+					try {
+						radioStatus = ReadValue(p[0].Handle, address_radio, false, true);
+					}
+					catch (InvalidOperationException) {
+						Debug.WriteLine("InvalidOperationException H");
+						gameStatus = statuses.Shutdown;
+						return;
+					}
+					catch (NullReferenceException) {
+						Debug.WriteLine("NullReferenceException H");
+						gameStatus = statuses.Shutdown;
+						return;
+					}
+					catch (IndexOutOfRangeException) {
+						Debug.WriteLine("IndexOutOfRangeException H");
+						gameStatus = statuses.Shutdown;
+						return;
+					}
+
+					Debug.WriteLine($"radioStatus: {radioStatus}");
+
+					if (radioStatus == 2 && isPaused == true) {
+						isPaused = false;
+						Task.Run(() => MuteUnMuteSpotify(isPaused));
+					}
+					else if (radioStatus == 7 && isPaused == false) {
+						isPaused = true;
+						Task.Run(() => MuteUnMuteSpotify(isPaused));
 					}
 				}
 			}
@@ -797,6 +831,50 @@ namespace GTASARadioExternal {
 			}
 		}
 
+		// Mutes or unmutes Spotify from Volume Mixer
+		public static void MuteUnMuteSpotify(bool mute) {
+			//Let's find the process ID for spotify (there can be multiple)
+			var processes = Process.GetProcessesByName("Spotify");
+			List<int> pids = new List<int>();
+			foreach (var p in processes) {
+				pids.Add(p.Id);
+			}
+
+			using (var sessionManager = GetDefaultAudioSessionManager2(DataFlow.Render)) {
+				using (var sessionEnumerator = sessionManager.GetSessionEnumerator()) {
+					foreach (var session in sessionEnumerator) {
+						using (var simpleVolume = session.QueryInterface<SimpleAudioVolume>())
+						using (var sessionControl = session.QueryInterface<AudioSessionControl2>()) {
+							// When we find the correct session for Spotify's process, set the volume to 0 or 1
+							if (pids.Contains(sessionControl.ProcessID)) {
+								if (mute)
+									simpleVolume.MasterVolume = 0.0f;
+								else
+									simpleVolume.MasterVolume = ((float)spotifyMixerMaxVolume) / 100.0f;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		private static AudioSessionManager2 GetDefaultAudioSessionManager2(DataFlow dataFlow) {
+			using (var enumerator = new MMDeviceEnumerator()) {
+				// Find the Audiosource Spotify uses (We can't use the Default Device, if someone has set Spotify to play music on a specific Audiosource)
+				var source = enumerator.EnumAudioEndpoints(dataFlow, DeviceState.Active).Where(s => s.FriendlyName.Contains(spotifyAudioSourceName)).FirstOrDefault();
+
+				if (source != null)
+					return AudioSessionManager2.FromMMDevice(source);
+
+				// If for some reason we can't find the specified source, use the Default Device
+				using (var device = enumerator.GetDefaultAudioEndpoint(dataFlow, Role.Multimedia)) {
+					Debug.WriteLine("DefaultDevice: " + device.FriendlyName);
+					var sessionManager = AudioSessionManager2.FromMMDevice(device);
+					return sessionManager;
+				}
+			}
+		}
+
 		// Change Radio based on pausing/unpausing
 		void RadioChangerPause(bool radioOff) {
 			radioActive = !radioOff;
@@ -829,7 +907,7 @@ namespace GTASARadioExternal {
 					keybd_event(0xAF, 0, 1, IntPtr.Zero);
 				}
 				keybd_event(0xAF, 0, 2, IntPtr.Zero);
-				
+
 
 				prevVolumeStatus = volumeStatus;
 				volumeStatus = checkMP3PlayerStatus();

--- a/GTASARadioExternal/ReadMemory.cs
+++ b/GTASARadioExternal/ReadMemory.cs
@@ -724,9 +724,6 @@ namespace GTASARadioExternal {
 						gameStatus = statuses.Shutdown;
 						return;
 					}
-
-					Debug.WriteLine($"radioStatus: {radioStatus}");
-
 					if (radioStatus == 2 && isPaused == true) {
 						isPaused = false;
 						Task.Run(() => MuteUnMuteSpotify(isPaused));
@@ -868,7 +865,7 @@ namespace GTASARadioExternal {
 
 				// If for some reason we can't find the specified source, use the Default Device
 				using (var device = enumerator.GetDefaultAudioEndpoint(dataFlow, Role.Multimedia)) {
-					Debug.WriteLine("DefaultDevice: " + device.FriendlyName);
+					//Debug.WriteLine("DefaultDevice: " + device.FriendlyName);
 					var sessionManager = AudioSessionManager2.FromMMDevice(device);
 					return sessionManager;
 				}

--- a/GTASARadioExternal/packages.config
+++ b/GTASARadioExternal/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CSCore" version="1.2.1.2" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Added a feature to mute/unmute Spotify in the Windows Volume Mixer. I wasn't familiar on how this software worked, so I copied the same method as in the Pause/Unpause hotkey function, and just switched it to mute the Spotify Application.

It gets the PIDs of "Spotify" named processes and uses [CSCore](https://github.com/filoe/cscore) to find the session with the Spotify's PID in a specific Audio Device Source. After that it sets the volume of that session to 0 or 100 (or whatever the user defined as the max volume) depending on does it need to mute or unmute. I also added a Dropdown menu where the user selects the right Audio Device where Spotify is playing, if it happens to be something else than the Default Device.

I tested it for some time and it seems to work fine. I added it only to SA since that's what I'm playing currently and could reliably test.

Also there was a typo when it saved the preferences to the config file and it didn't save the "Other" selection:
else if (radioButtonVolume.Checked) Should have been (?):
else if (radioButtonOther.Checked)